### PR TITLE
Remove extra plainToClass

### DIFF
--- a/src/sentiment/sentiment.controller.ts
+++ b/src/sentiment/sentiment.controller.ts
@@ -18,7 +18,7 @@ import { SentimentService } from './sentiment.service';
 @ApiTags('sentiments')
 @Controller('sentiments')
 export class SentimentController {
-  constructor(private readonly service: SentimentService) {}
+  constructor(private readonly service: SentimentService) { }
 
   @Post()
   @ApiOperation({ summary: 'Compute the sentiment of text' })
@@ -44,7 +44,6 @@ export class SentimentController {
   @ApiOperation({ summary: 'Get all recorded sentiment computations' })
   @ApiOkResponse({ type: [SentimentDTO] })
   async getAll(): Promise<SentimentDTO[]> {
-    const result = await this.service.getAllSentiments();
-    return plainToClass(SentimentDTO, result);
+    return await this.service.getAllSentiments();
   }
 }


### PR DESCRIPTION
### Changes

- Removes unnecessary `plainToClass` call in `SentimentController.getAll` handler

### References

- Closes #1 