### PR TITLE
Add ObjectId Pipe

### DIFF
--- a/src/platform/pipes/objectId.pipe.spec.ts
+++ b/src/platform/pipes/objectId.pipe.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Types } from 'mongoose';
+import { ParseObjectIdPipe } from './objectId.pipe';
+
+describe('ParseObjectIdPipe', () => {
+  let pipe: ParseObjectIdPipe;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ParseObjectIdPipe],
+    }).compile();
+
+    pipe = module.get<ParseObjectIdPipe>(ParseObjectIdPipe);
+  });
+
+  it('should transform the provided string into an ObjectId', () => {
+    const id = new Types.ObjectId();
+    const hexId = id.toHexString();
+    const result = pipe.transform(hexId);
+    expect(result.toHexString()).toBe(hexId);
+  });
+
+  it('should throw if string is invalid', () => {
+    expect(() => pipe.transform('invalid')).toThrow('Invalid ID');
+  });
+});

--- a/src/platform/pipes/objectId.pipe.ts
+++ b/src/platform/pipes/objectId.pipe.ts
@@ -1,0 +1,18 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { Types } from 'mongoose';
+
+@Injectable()
+export class ParseObjectIdPipe
+  implements PipeTransform<unknown, Types.ObjectId>
+{
+  transform(value: unknown): Types.ObjectId {
+    const valueAsString = `${value}`;
+    const isValidObjectId = Types.ObjectId.isValid(valueAsString);
+
+    if (!isValidObjectId) {
+      throw new BadRequestException('Invalid ID');
+    }
+
+    return Types.ObjectId.createFromHexString(valueAsString);
+  }
+}

--- a/src/sentiment/sentiment.controller.spec.ts
+++ b/src/sentiment/sentiment.controller.spec.ts
@@ -8,6 +8,7 @@ import { SentimentController } from './sentiment.controller';
 import { Sentiment } from './sentiment.schema';
 import { SentimentService } from './sentiment.service';
 import { generateSentimentDTO, generateSentimentDTOs } from './test-utils/data';
+import { Types } from 'mongoose';
 
 describe('SentimentController', () => {
   let controller: SentimentController;
@@ -55,7 +56,9 @@ describe('SentimentController', () => {
         .spyOn(mockSentimentService, 'getSentimentById')
         .mockImplementationOnce(async () => expected);
 
-      const result = await controller.getOne(expected.id);
+      const result = await controller.getOne(
+        Types.ObjectId.createFromHexString(expected.id),
+      );
 
       expect(result).toBe(expected);
     });
@@ -67,7 +70,9 @@ describe('SentimentController', () => {
           throw new Error('error');
         }) as jest.Mock);
 
-      await expect(() => controller.getOne('test')).rejects.toThrow('error');
+      await expect(() =>
+        controller.getOne(new Types.ObjectId()),
+      ).rejects.toThrow('error');
     });
   });
 

--- a/src/sentiment/sentiment.controller.ts
+++ b/src/sentiment/sentiment.controller.ts
@@ -13,6 +13,8 @@ import {
   SentimentScoreDTO,
 } from './sentiment.dto';
 import { SentimentService } from './sentiment.service';
+import { Types } from 'mongoose';
+import { ParseObjectIdPipe } from 'src/platform/pipes/objectId.pipe';
 
 @ApiTags('sentiments')
 @Controller('sentiments')
@@ -31,11 +33,13 @@ export class SentimentController {
   @ApiOperation({
     summary: 'Get a recorded sentiment computation by id',
   })
-  @ApiParam({ name: 'id' })
+  @ApiParam({ name: 'id', type: Types.ObjectId })
   @ApiOkResponse({ type: SentimentDTO })
   @ApiNotFoundResponse()
   @ApiBadRequestResponse()
-  async getOne(@Param('id') id: string): Promise<SentimentDTO> {
+  async getOne(
+    @Param('id', ParseObjectIdPipe) id: Types.ObjectId,
+  ): Promise<SentimentDTO> {
     return this.service.getSentimentById(id);
   }
 

--- a/src/sentiment/sentiment.service.spec.ts
+++ b/src/sentiment/sentiment.service.spec.ts
@@ -115,18 +115,9 @@ describe('SentimentService', () => {
         .spyOn(mockSentimentModel, 'findById')
         .mockResolvedValueOnce(sentiment);
 
-      const result = await service.getSentimentById(
-        sentiment._id.toHexString(),
-      );
+      const result = await service.getSentimentById(sentiment._id);
 
       expect(result.id).toBe(sentiment._id.toHexString());
-    });
-
-    it('should throw if id is invalid', async () => {
-      jest.spyOn(mockSentimentModel, 'findById').mockResolvedValueOnce(null);
-      await expect(() => service.getSentimentById('')).rejects.toThrow(
-        'Invalid ID',
-      );
     });
 
     it('should throw on database error', async () => {
@@ -135,16 +126,16 @@ describe('SentimentService', () => {
         .mockImplementationOnce((async () => {
           throw new Error('Something went wrong');
         }) as jest.Mock);
-      const hexId = new Types.ObjectId().toHexString();
-      await expect(() => service.getSentimentById(hexId)).rejects.toThrow(
+      const id = new Types.ObjectId();
+      await expect(() => service.getSentimentById(id)).rejects.toThrow(
         'Something went wrong',
       );
     });
 
     it('should thow not found if sentiment does not exist', async () => {
-      const hexId = new Types.ObjectId().toHexString();
+      const id = new Types.ObjectId();
       jest.spyOn(mockSentimentModel, 'findById').mockResolvedValueOnce(null);
-      await expect(() => service.getSentimentById(hexId)).rejects.toThrow(
+      await expect(() => service.getSentimentById(id)).rejects.toThrow(
         'Not Found',
       );
     });

--- a/src/sentiment/sentiment.service.ts
+++ b/src/sentiment/sentiment.service.ts
@@ -1,15 +1,13 @@
 import {
-  BadRequestException,
   Injectable,
-  NotFoundException,
+  NotFoundException
 } from '@nestjs/common';
-import { LoggerService } from 'src/platform/services/logger.service';
-import { LanguageService } from 'src/platform/services/language.service';
-import { SentimentScoreDTO, SentimentDTO } from './sentiment.dto';
 import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { LanguageService } from 'src/platform/services/language.service';
+import { LoggerService } from 'src/platform/services/logger.service';
+import { SentimentDTO, SentimentScoreDTO } from './sentiment.dto';
 import { Sentiment } from './sentiment.schema';
-import { Model } from 'mongoose';
-import { Types } from 'mongoose';
 
 @Injectable()
 export class SentimentService {
@@ -51,20 +49,8 @@ export class SentimentService {
     return result;
   }
 
-  async getSentimentById(id: string): Promise<SentimentDTO> {
-    let result: Sentiment | null;
-
-    try {
-      const _id = Types.ObjectId.createFromHexString(id);
-      result = await this.sentimentModel.findById(_id);
-    } catch (err) {
-      switch (err.name) {
-        case 'BSONError':
-          throw new BadRequestException('Invalid ID');
-        default:
-          throw err;
-      }
-    }
+  async getSentimentById(id: Types.ObjectId): Promise<SentimentDTO> {
+    const result = await this.sentimentModel.findById(id);
 
     if (!result) {
       throw new NotFoundException();


### PR DESCRIPTION
### Changes

- Adds `ParseObjectIdPipe` and uses in `SentimentController.getOne` to parse `id` parameter as an ObjectId
- Adds tests for `ParseObjectIdPipe`
- Removes ObjectId validation from `SentimentService` and updates tests


### References

- Closes #2 